### PR TITLE
distance-interactor: Fix interaction broken due to latest grip change

### DIFF
--- a/src/components/interactor.ts
+++ b/src/components/interactor.ts
@@ -8,6 +8,15 @@ export enum Handedness {
     Right = 'right',
     Left = 'left',
 }
+
+/**
+ * Mapping from button name to their index in [Gamepad.buttons](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/buttons).
+ */
+export enum GamepadButtonBinding {
+    Trigger = 0,
+    Grip = 1,
+}
+
 export const HandednessValues = Object.values(Handedness);
 
 /**
@@ -174,6 +183,13 @@ export class Interactor extends Component {
      */
     get xrPose(): XRPose | null {
         return this.#xrPose;
+    }
+
+    /**
+     * Current [XR input source](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource).
+     */
+    get xrInputSource(): XRInputSource | null {
+        return this.#xrInputSource;
     }
 
     /**


### PR DESCRIPTION
Basically I introduced a change to trigger `onGripStart/End`, but the distance interactor was using those. In general, we should move away from the events and simply read the state of the controllers.

I created this library to improve input<>actions: https://github.com/DavidPeicho/haptic-js

I just don't know if it's worth going the extra mile and coupling this interaction library to an input system. If we can implement all our features behind a `useDefaultInputs` flag that would be great.

BTW: Didn't run prettier on purpose si we can merge your MR without too much conflicts.